### PR TITLE
chore: enable Nvidia 550 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         fedora-version: [39]
         fedora-edition: [base, silverblue]
-        nvidia-version: [545]
+        nvidia-version: [545, 550]
         include:
           - nvidia-version: 545
             nvidia-is-stable: true


### PR DESCRIPTION
Only enable builds.  Do not make them stable yet, so nobody should use it