### PR TITLE
chore: auto generate containerfile

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: "Cache source for Podman build (optional)"
     required: false
     default: ""
+  cache-ttl:
+    description: "Cache TTL for Podman build (optional)"
+    required: false
+    default: ""
 
 outputs:
   image:
@@ -64,6 +68,7 @@ runs:
         RECHUNK: ${{ inputs.rechunk }}
         CACHE_TO: ${{ inputs.cache-to }}
         CACHE_FROM: ${{ inputs.cache-from }}
+        CACHE_TTL: ${{ inputs.cache-ttl }}
       run: |
         set -x
 
@@ -112,6 +117,9 @@ runs:
           CACHE_ARGS+=("--cache-to=$CACHE_TO" "--layers")
           if [[ -n "$CACHE_FROM" ]]; then
             CACHE_ARGS+=("--cache-from=$CACHE_FROM")
+          fi
+          if [[ -n "$CACHE_TTL" ]]; then
+            CACHE_ARGS+=("--cache-ttl=$CACHE_TTL")
           fi
         fi
         $podman build \

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -31,6 +31,14 @@ inputs:
   rechunk-prev-ref:
     description: "Previous image reference to use when rechunking"
     required: false
+  cache-to:
+    description: "Cache destination for Podman build (optional)"
+    required: false
+    default: ""
+  cache-from:
+    description: "Cache source for Podman build (optional)"
+    required: false
+    default: ""
 
 outputs:
   image:
@@ -54,6 +62,8 @@ runs:
         SECRETS_INPUT: ${{ inputs.secrets }}
         TAG: ${{ inputs.image-tag }}
         RECHUNK: ${{ inputs.rechunk }}
+        CACHE_TO: ${{ inputs.cache-to }}
+        CACHE_FROM: ${{ inputs.cache-from }}
       run: |
         set -x
 
@@ -97,9 +107,17 @@ runs:
           set -x
         } 2>/dev/null
 
+        CACHE_ARGS=()
+        if [[ -n "$CACHE_TO" ]]; then
+          CACHE_ARGS+=("--cache-to=$CACHE_TO" "--layers")
+          if [[ -n "$CACHE_FROM" ]]; then
+            CACHE_ARGS+=("--cache-from=$CACHE_FROM")
+          fi
+        fi
         $podman build \
           ${BUILD_ARGS[@]} \
           ${SECRETS[@]} \
+          ${CACHE_ARGS[@]} \
           -t ${{ inputs.image-name }}:$TAG \
           -f ${{ inputs.containerfile }} \
           ${{ inputs.context }}

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -27,10 +27,6 @@ on:
         required: false
         type: boolean
         default: false
-      containerfile:
-        required: false
-        type: string
-        default: ./Containerfile
       build-context:
         required: false
         type: string
@@ -125,12 +121,17 @@ jobs:
         with:
           coreos-stream: ${{ inputs.kernel-flavor }}
 
+      - name: Generate Containerfile
+        id: generate-containerfile
+        run: |
+          ./generate.sh
+
       - name: Build Image
         id: build
         uses: ./.github/actions/build-image
         with:
           context: ${{ inputs.build-context }}
-          containerfile: ${{ inputs.containerfile }}
+          containerfile: ./Containerfile.gen
           image-name: ${{ inputs.image-name }}
           image-tag: local
           build-args: |
@@ -363,7 +364,7 @@ jobs:
         uses: ./.github/actions/build-image
         with:
           context: ${{ inputs.build-context }}
-          containerfile: ${{ inputs.containerfile }}.nvidia
+          containerfile: ./Containerfile.nvidia
           image-name: ${{ inputs.image-name }}
           image-tag: local
           build-args: |

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -133,8 +133,6 @@ jobs:
           context: ${{ inputs.build-context }}
           containerfile: ./Containerfile.gen
           image-name: ${{ inputs.image-name }}
-          cache-to: ghcr.io/${{ github.repository_owner }}/cache
-          cache-from: ghcr.io/${{ github.repository_owner }}/cache
           image-tag: local
           build-args: |
             MAJOR_VERSION=${{ inputs.major-version }}
@@ -142,6 +140,9 @@ jobs:
             ${{ inputs.kernel-flavor != 'default' && format('COREOS_KERNEL={0}', steps.get-coreos-kernel.outputs.coreos-kernel-release) || '' }}
             ${{ inputs.kernel-flavor != 'default' && format('AKMODS_TAG={0}', inputs.kernel-flavor) || '' }}
             ${{ inputs.source-image != '' && format('IMAGE_REGISTRY={0}', inputs.source-image) || '' }}
+          cache-to: ghcr.io/${{ github.repository_owner }}/cache
+          cache-from: ghcr.io/${{ github.repository_owner }}/cache
+          cache-ttl: 24h
           rechunk: ${{ inputs.rechunk }}
           rechunk-prev-ref: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ steps.generate-image-tags.outputs.stable-tag }}
 
@@ -373,6 +374,9 @@ jobs:
             BASE_IMAGE_FULL=${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}@${{ steps.load-outputs.outputs.DIGEST }}
             MAJOR_VERSION=${{ inputs.major-version }}
             ${{ inputs.kernel-flavor != 'default' && format('NVIDIA_AKMODS_TAG={0}', inputs.kernel-flavor) || '' }}
+          cache-to: ghcr.io/${{ github.repository_owner }}/cache
+          cache-from: ghcr.io/${{ github.repository_owner }}/cache
+          cache-ttl: 24h
           rechunk: ${{ inputs.rechunk }}
           rechunk-prev-ref: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name }}:${{ steps.generate-image-tags.outputs.stable-tag }}
 

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -133,6 +133,8 @@ jobs:
           context: ${{ inputs.build-context }}
           containerfile: ./Containerfile.gen
           image-name: ${{ inputs.image-name }}
+          cache-to: ghcr.io/${{ github.repository_owner }}/cache
+          cache-from: ghcr.io/${{ github.repository_owner }}/cache
           image-tag: local
           build-args: |
             MAJOR_VERSION=${{ inputs.major-version }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,42 +37,42 @@ jobs:
       kernel-flavor: ${{ matrix.kernel-flavor }}
       source-image: quay.io/fedora/fedora-silverblue
 
-  build-cosmic:
-    uses: ./.github/workflows/_build-image.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        major-version: [42]
-        kernel-flavor: [default, stable]
-        exclude:
-          - major-version: 42
-            kernel-flavor: stable
-    secrets: inherit
-    with:
-      image-name: eternal-linux/main/cosmic
-      desktop-environment: cosmic
-      major-version: ${{ matrix.major-version }}
-      is-release: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && startsWith(github.ref, 'refs/heads/main') }}
-      platforms: amd64 arm64
-      kernel-flavor: ${{ matrix.kernel-flavor }}
-      source-image: quay.io/fedora-ostree-desktops/cosmic-atomic
+  # build-cosmic:
+  #   uses: ./.github/workflows/_build-image.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       major-version: [42]
+  #       kernel-flavor: [default, stable]
+  #       exclude:
+  #         - major-version: 42
+  #           kernel-flavor: stable
+  #   secrets: inherit
+  #   with:
+  #     image-name: eternal-linux/main/cosmic
+  #     desktop-environment: cosmic
+  #     major-version: ${{ matrix.major-version }}
+  #     is-release: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && startsWith(github.ref, 'refs/heads/main') }}
+  #     platforms: amd64 arm64
+  #     kernel-flavor: ${{ matrix.kernel-flavor }}
+  #     source-image: quay.io/fedora-ostree-desktops/cosmic-atomic
 
-  build-kde:
-    uses: ./.github/workflows/_build-image.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        major-version: [42]
-        kernel-flavor: [default, stable]
-        exclude:
-          - major-version: 42
-            kernel-flavor: stable
-    secrets: inherit
-    with:
-      image-name: eternal-linux/main/kinoite
-      desktop-environment: kde
-      major-version: ${{ matrix.major-version }}
-      is-release: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && startsWith(github.ref, 'refs/heads/main') }}
-      platforms: amd64 arm64
-      kernel-flavor: ${{ matrix.kernel-flavor }}
-      source-image: quay.io/fedora/fedora-kinoite
+  # build-kde:
+  #   uses: ./.github/workflows/_build-image.yml
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       major-version: [42]
+  #       kernel-flavor: [default, stable]
+  #       exclude:
+  #         - major-version: 42
+  #           kernel-flavor: stable
+  #   secrets: inherit
+  #   with:
+  #     image-name: eternal-linux/main/kinoite
+  #     desktop-environment: kde
+  #     major-version: ${{ matrix.major-version }}
+  #     is-release: ${{ (github.event_name == 'schedule' || github.event_name == 'push') && startsWith(github.ref, 'refs/heads/main') }}
+  #     platforms: amd64 arm64
+  #     kernel-flavor: ${{ matrix.kernel-flavor }}
+  #     source-image: quay.io/fedora/fedora-kinoite

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .idea
+Containerfile.gen

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DESKTOP_ENVIRONMENT="${1:-gnome}"  # default gnome
+MAJOR_VERSION=42
+IMAGE_REGISTRY="quay.io/fedora/fedora-silverblue"
+FEDORA_IMAGE="${IMAGE_REGISTRY}:${MAJOR_VERSION}"
+AKMODS_TAG="${MAJOR_VERSION}"
+COREOS_KERNEL="N/A"
+
+OUTPUT="Containerfile.gen"
+
+echo "Generating $OUTPUT for desktop environment: $DESKTOP_ENVIRONMENT"
+
+# Start fresh
+cat > "$OUTPUT" <<EOF
+# syntax=docker/dockerfile:1.4
+ARG MAJOR_VERSION=${MAJOR_VERSION}
+ARG DESKTOP_ENVIRONMENT=${DESKTOP_ENVIRONMENT}
+ARG IMAGE_REGISTRY=${IMAGE_REGISTRY}
+ARG FEDORA_IMAGE=\${IMAGE_REGISTRY}:\${MAJOR_VERSION}
+ARG AKMODS_TAG=${AKMODS_TAG}
+ARG COREOS_KERNEL=${COREOS_KERNEL}
+
+FROM \${FEDORA_IMAGE} AS base
+
+ARG DESKTOP_ENVIRONMENT
+ARG MAJOR_VERSION
+ARG AKMODS_TAG
+ARG COREOS_KERNEL
+
+COPY files/_base/ /
+COPY files/_${DESKTOP_ENVIRONMENT}* /
+
+COPY --from=ghcr.io/rsturla/akmods/v4l2loopback:\${AKMODS_TAG} /rpms /tmp/akmods/rpms
+COPY --from=ghcr.io/rsturla/akmods/v4l2loopback:\${AKMODS_TAG} /scripts /tmp/akmods/scripts/v4l2loopback
+
+RUN mkdir -p /scripts
+
+EOF
+
+# Add base scripts
+for script in scripts/_base/*.sh; do
+  filename=$(basename "$script")
+  echo "COPY --chmod=755 scripts/_base/${filename} /scripts/${filename}" >> "$OUTPUT"
+  echo "RUN --mount=type=cache,target=/var/cache \\" >> "$OUTPUT"
+  echo "    --mount=type=cache,target=/var/lib \\" >> "$OUTPUT"
+  echo "    --mount=type=cache,target=/var/log \\" >> "$OUTPUT"
+  echo "    --mount=type=cache,target=/var/tmp \\" >> "$OUTPUT"
+  echo "    --mount=type=tmpfs,target=/tmp \\" >> "$OUTPUT"
+  echo "    /bin/bash /scripts/${filename}" >> "$OUTPUT"
+  echo "" >> "$OUTPUT"
+done
+
+# Add desktop environment scripts, if not base
+if [[ "$DESKTOP_ENVIRONMENT" != "base" ]]; then
+  for script in scripts/_${DESKTOP_ENVIRONMENT}/*.sh; do
+    filename=$(basename "$script")
+    echo "COPY --chmod=755 scripts/_${DESKTOP_ENVIRONMENT}/${filename} /scripts/${filename}" >> "$OUTPUT"
+    echo "RUN --mount=type=cache,target=/var/cache \\" >> "$OUTPUT"
+    echo "    --mount=type=cache,target=/var/lib \\" >> "$OUTPUT"
+    echo "    --mount=type=cache,target=/var/log \\" >> "$OUTPUT"
+  echo "    --mount=type=cache,target=/var/tmp \\" >> "$OUTPUT"
+    echo "    --mount=type=tmpfs,target=/tmp \\" >> "$OUTPUT"
+    echo "    /bin/bash /scripts/${filename}" >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+  done
+fi
+
+# Add cleanup script
+echo "COPY --chmod=755 scripts/cleanup.sh /scripts/cleanup.sh" >> "$OUTPUT"
+echo "RUN --mount=type=cache,target=/var/cache \\" >> "$OUTPUT"
+echo "    --mount=type=cache,target=/var/lib \\" >> "$OUTPUT"
+echo "    --mount=type=cache,target=/var/log \\" >> "$OUTPUT"
+  echo "    --mount=type=cache,target=/var/tmp \\" >> "$OUTPUT"
+echo "    --mount=type=tmpfs,target=/tmp \\" >> "$OUTPUT"
+echo "    /bin/bash /scripts/cleanup.sh --base ${DESKTOP_ENVIRONMENT}" >> "$OUTPUT"
+
+echo ""
+echo "✅ $OUTPUT generated."

--- a/scripts/_gnome/002-gnome-software.sh
+++ b/scripts/_gnome/002-gnome-software.sh
@@ -7,11 +7,4 @@ dnf -y copr enable ublue-os/staging
 dnf remove -y \
   gnome-software-rpm-ostree
 
-dnf remove -y \
-  gnome-software
-
-dnf install -y \
-  --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-  gnome-software
-
 rm -rf /etc/yum.repos.d/_copr_ublue-os_staging.repo

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -9,6 +9,3 @@ mkdir -p /var/tmp
 KERNEL_SUFFIX=""
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
 /usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
-
-# Clear out unsupported directories
-rm -rf /tmp/* /var/*


### PR DESCRIPTION
This pull request introduces improvements to the image build process, mainly by adding support for build cache configuration and automating the generation of the `Containerfile` used in image creation. These changes help optimize build times and streamline the workflow for building different desktop environments.

**Image build cache support:**
* Added new inputs `cache-to`, `cache-from`, and `cache-ttl` to `.github/actions/build-image/action.yml` to enable Podman build cache configuration, allowing for faster and more efficient image builds.
* Updated the build step logic to pass cache arguments to Podman when the cache inputs are set, making use of the new cache configuration.
* Modified workflow job steps in `.github/workflows/_build-image.yml` to set cache parameters for both standard and NVIDIA image builds, ensuring cache is utilized across builds. [[1]](diffhunk://#diff-a06240d96190a21203a43a444cb74a8097d8a66c8965a7644cf44bd38b764349R143-R145) [[2]](diffhunk://#diff-a06240d96190a21203a43a444cb74a8097d8a66c8965a7644cf44bd38b764349L366-R379)

**Containerfile generation automation:**
* Added a new script `generate.sh` to programmatically generate `Containerfile.gen` based on the selected desktop environment, simplifying customization and maintenance of build instructions.
* Updated workflow steps to use the generated `Containerfile.gen` instead of a static file, and removed the unused `containerfile` input from the workflow. [[1]](diffhunk://#diff-a06240d96190a21203a43a444cb74a8097d8a66c8965a7644cf44bd38b764349L30-L33) [[2]](diffhunk://#diff-a06240d96190a21203a43a444cb74a8097d8a66c8965a7644cf44bd38b764349R124-R134)

**Other minor changes:**
* Cleaned up the GNOME software installation script by removing redundant installation commands.
* Removed an unnecessary cleanup step from the `cleanup.sh` script to avoid deleting directories that may be needed post-build.