### PR TITLE
feat: add openh264 codec packages

### DIFF
--- a/scripts/_base/007-install-packages.sh
+++ b/scripts/_base/007-install-packages.sh
@@ -8,8 +8,10 @@ dnf install -y \
   ffmpeg \
   ffmpeg-libs \
   fzf \
+  gstreamer1-plugin-openh264 \
   htop \
   just \
+  openh264 \
   openssl \
   parallel \
   tmux \


### PR DESCRIPTION
## Summary
- Add `openh264` and `gstreamer1-plugin-openh264` to base package list
- Enables native H.264 encoding for GNOME 46+ screencasts
- Without these, GNOME falls back to WebM/VP8 format

## Context
GNOME Shell [checks for H.264 support](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3211) at screencast time. Missing codec means screencasts save as `.webm` instead of `.mp4`. Packages resolve from the Negativo17 multimedia repo already configured in `005-negativo17.sh`.

## Test plan
- [ ] Build image successfully with new packages
- [ ] Verify `gst-inspect-1.0 openh264enc` shows encoder details in built image
- [ ] Record screencast in GNOME — confirm output is `.mp4`