### PR TITLE
fix(iso): pull image before titanoboa build

### DIFF
--- a/.github/workflows/_build-iso.yml
+++ b/.github/workflows/_build-iso.yml
@@ -83,6 +83,18 @@ jobs:
 
           echo "ROOTFS_SETUP_HOOK=${WORKSPACE_DIR}/rootfs-setup-hook.sh" >> $GITHUB_OUTPUT
 
+      # Titanoboa runs `sudo podman run --mount type=image,source=<ref>` which
+      # does not pull the image and reads from root podman storage. Pre-pull the
+      # image with sudo so it is present locally; otherwise the run fails with
+      # "image not known".
+      - name: Pull Image
+        shell: bash
+        env:
+          IMAGE_REF: ${{ inputs.image-registry }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+        run: |
+          set -euox pipefail
+          sudo podman pull "$IMAGE_REF"
+
       - name: Build ISO
         uses: ublue-os/titanoboa@5c457c3d0518bd17e754be0fd98a60d29d26abb4 # main
         id: build-iso


### PR DESCRIPTION
## Problem

ISO builds fail at the titanoboa step:

```
Error: creating image volume "ghcr.io/rsturla/eternal-linux/lumina:44-nvidia":"/rootfs": ghcr.io/rsturla/eternal-linux/lumina:44-nvidia: image not known
+ ISO_FILENAME=
Error: Process completed with exit code 126.
```

## Root cause

Titanoboa's `main.sh` runs:

```sh
sudo podman run --mount type=image,source="$TITANOBOA_CTR_IMAGE",dst=/rootfs ...
```

`--mount type=image` does **not** pull the image — it requires the image to already be in local storage. It also uses `sudo podman`, so the image must be in **root** podman storage. Neither titanoboa's `action.yml` nor `main.sh` pulls the image, and this reusable workflow didn't either, so the image-volume mount fails with "image not known".

The target image itself is fine (`ghcr.io/rsturla/eternal-linux/lumina:44-nvidia` exists and is publicly pullable).

## Fix

Add a `Pull Image` step that runs `sudo podman pull "$IMAGE_REF"` (root storage, matching titanoboa's `sudo podman run`) before the Build ISO step.